### PR TITLE
slow down url opening

### DIFF
--- a/OpenURLS.popclipext/openurls.rb
+++ b/OpenURLS.popclipext/openurls.rb
@@ -63,6 +63,7 @@ urls.each {|url|
 
     unless debug
       %x{open '#{target}'}
+      sleep 1
     else
       o += target + "\n"
     end


### PR DESCRIPTION
before this change the list of URLs was sent to chrome so quickly that chrome "lost" about half of the urls given a list of 25. The sleep gives Chrome enough time to create the tab so that all the URL are opened properly.
