### PR TITLE
Fix substitution typo in ruby script.

### DIFF
--- a/CriticMarkup.popclipext/script.rb
+++ b/CriticMarkup.popclipext/script.rb
@@ -12,7 +12,7 @@ commentmarkup = comment == "" ? "" : "{>>#{comment} - #{Time.now.strftime('%F %T
 
 date = Time.now.strftime('datetime="%FT%T%z"')
 ctrlcmdprefix = "{~~"
-ctrlcmdsuffix = "-> ~~}"
+ctrlcmdsuffix = "~> ~~}"
 ctrlprefix = "{++"
 ctrlsuffix = "++}"
 cmdprefix = "{--"


### PR DESCRIPTION
This fix is for the CriticMarkup PopClip extension.  The substitution markup was using `->` and should have been using `~>`. 
