### PR TITLE
Remove lines that are not Headings or Lists

### DIFF
--- a/Markdown2Mindmap.popclipext/md2mm.rb
+++ b/Markdown2Mindmap.popclipext/md2mm.rb
@@ -20,6 +20,8 @@ lines = outdent(input).split("\n")
 # Remove blank lines
 lines.delete_if {|line| line =~ /^\s*$/}
 
+# Remove lines that are not headings or lists
+lines.delete_if {|line| line =~ /^(?!(#|\s*(\d\.|[\-\*\+])\s)).+/}
 
 # Handle converting headlines and lists to indented outline
 last_level = 0


### PR DESCRIPTION
Mindmap’s should only show the structure of a document. So remove all
all non-headings and lists. **This will break Brett’s “plain text lists”
example.**

I like to use "Markdown to Mind Map" to view the structure of larger project management documents. For this use case, I don't want to see the paragraphs, code blocks, second lines of list items, etc. 

Brett's examples for "Markdown to Mindmap"  shows the use of what he calls "plain text lists' which would be rendered by standard Markdown as a paragraph. I don't use that, so my change will break that behavior. Perhaps this needs to be implement as a alternative version?

I only use this as System Service, but I only found the popclip extensions on GitHub. 
